### PR TITLE
Use and generate enum instead of defined constants

### DIFF
--- a/BtYacc-w32-vs120.sln
+++ b/BtYacc-w32-vs120.sln
@@ -6,6 +6,9 @@ MinimumVisualStudioVersion = 10.0.40219.1
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "BtYacc", "BtYacc-w32-vs120.vcxproj", "{F65CE8B2-964C-4CDF-90CE-3D8E36B9442C}"
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "testsuite", "test\testsuite-w32-vs120.vcxproj", "{8192E190-6FA2-4D3C-9BD7-8D82B319837F}"
+	ProjectSection(ProjectDependencies) = postProject
+		{F65CE8B2-964C-4CDF-90CE-3D8E36B9442C} = {F65CE8B2-964C-4CDF-90CE-3D8E36B9442C}
+	EndProjectSection
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/BtYacc-w32-vs120.vcxproj
+++ b/BtYacc-w32-vs120.vcxproj
@@ -97,7 +97,6 @@
     <None Include="..\test\ftp.y" />
     <None Include="..\test\t1.y" />
     <None Include="..\test\t2.y" />
-    <None Include="..\test\t3.y" />
     <None Include="..\test\test.y" />
     <None Include="btyaccpa.ske" />
     <None Include="CHANGELOG" />
@@ -108,6 +107,7 @@
     <None Include="README" />
     <None Include="README.BYACC" />
     <None Include="skel2c" />
+    <None Include="test\t3.y" />
   </ItemGroup>
   <ItemGroup>
     <Text Include="..\CMakeLists.txt" />

--- a/BtYacc-w32-vs120.vcxproj
+++ b/BtYacc-w32-vs120.vcxproj
@@ -80,17 +80,8 @@
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>
-    <None Include="..\btyaccpa.ske" />
     <None Include="..\build.h.in" />
-    <None Include="..\CHANGELOG" />
     <None Include="..\empty.y" />
-    <None Include="..\Makefile" />
-    <None Include="..\makefile.dos" />
-    <None Include="..\manpage" />
-    <None Include="..\push.skel" />
-    <None Include="..\README" />
-    <None Include="..\README.BYACC" />
-    <None Include="..\skel2c" />
     <None Include="..\test\ansiC.y" />
     <None Include="..\test\ansiC2.y" />
     <None Include="..\test\error.y" />

--- a/BtYacc-w32-vs120.vcxproj.filters
+++ b/BtYacc-w32-vs120.vcxproj.filters
@@ -49,9 +49,6 @@
     <None Include="..\README.BYACC" />
     <None Include="..\makefile.dos" />
     <None Include="..\build.h.in" />
-    <None Include="..\test\t3.y">
-      <Filter>test</Filter>
-    </None>
     <None Include="..\CHANGELOG" />
     <None Include="CHANGELOG" />
     <None Include="Makefile" />
@@ -62,6 +59,9 @@
     <None Include="makefile.dos" />
     <None Include="btyaccpa.ske" />
     <None Include="push.skel" />
+    <None Include="test\t3.y">
+      <Filter>test</Filter>
+    </None>
   </ItemGroup>
   <ItemGroup>
     <Text Include="..\CMakeLists.txt" />

--- a/BtYacc-w32-vs120.vcxproj.filters
+++ b/BtYacc-w32-vs120.vcxproj.filters
@@ -18,8 +18,6 @@
     </Filter>
   </ItemGroup>
   <ItemGroup>
-    <None Include="..\btyaccpa.ske" />
-    <None Include="..\push.skel" />
     <None Include="..\empty.y" />
     <None Include="..\test\ansiC.y">
       <Filter>test</Filter>
@@ -42,14 +40,7 @@
     <None Include="..\test\test.y">
       <Filter>test</Filter>
     </None>
-    <None Include="..\Makefile" />
-    <None Include="..\manpage" />
-    <None Include="..\README" />
-    <None Include="..\skel2c" />
-    <None Include="..\README.BYACC" />
-    <None Include="..\makefile.dos" />
     <None Include="..\build.h.in" />
-    <None Include="..\CHANGELOG" />
     <None Include="CHANGELOG" />
     <None Include="Makefile" />
     <None Include="manpage" />

--- a/defs.h
+++ b/defs.h
@@ -45,7 +45,7 @@ typedef int Yshort;
 /*  character names  */
 
 #define	NUL		'\0'    /*  the null character  */
-#define	NEWLINE		'\n'    /*  line feed  */
+#define	NL		'\n'    /*  line feed  */
 #define	SP		' '     /*  space  */
 #define	BS		'\b'    /*  backspace  */
 #define	HT		'\t'    /*  horizontal tab  */
@@ -71,39 +71,43 @@ typedef int Yshort;
 #define VERBOSE_SUFFIX  ".output"
 
 /* keyword codes */
-
-#define TOKEN 0
-#define LEFT 1
-#define RIGHT 2
-#define NONASSOC 3
-#define MARK 4
-#define TEXT 5
-#define TYPE 6
-#define START 7
-#define UNION 8
-#define IDENT 9
-#define DESTRUCTOR 10
-#define LOCATION 11
+enum Keyword {
+    TOKEN		= 0,
+    LEFT		= 1,
+    RIGHT		= 2,
+    NONASSOC 	= 3,
+    MARK 		= 4,
+    TEXT 		= 5,
+    TYPE 		= 6,
+    START 		= 7,
+    UNION 		= 8,
+    IDENT 		= 9,
+    DESTRUCTOR 	= 10,
+    LOCATION 	= 11
+};
 
 
 /*  symbol classes  */
-
-#define UNKNOWN 0
-#define TERM 1
-#define NONTERM 2
-#define ACTION 3
-#define ARGUMENT 4
+enum Symbol {
+    UNKNOWN	= 0,
+    TERM	= 1,
+    NONTERM	= 2,
+    ACTION	= 3,
+    ARGUMENT= 4
+};
 
 
 /*  the undefined value  */
-
-#define UNDEFINED (-1)
+enum Value {
+    UNDEFINED = -1
+};
 
 
 /*  action codes  */
-
-#define SHIFT 1
-#define REDUCE 2
+enum Action {
+    SHIFT	= 1,
+    REDUCE	= 2
+};
 
 
 /*  character macros  */

--- a/output.c
+++ b/output.c
@@ -855,12 +855,25 @@ void output_defines()
     /* VM: Print to either code file or defines file but not to both */
     dc_file = dflag ? defines_file : code_file;
 
+	if (ntokens > 2) {
+    int empty = 1;
+    for (i = 2; i < ntokens; ++i)
+	if (is_C_identifier(symbol_name[i])) 
+		empty = 0;
+
+	if (!empty) {
+	fprintf(dc_file, "\nenum\n");
+	fprintf(dc_file, "#ifdef __cplusplus\n");
+	fprintf(dc_file, "class\n");
+	fprintf(dc_file, "#endif\n");
+	fprintf(dc_file, "YYTOKEN {\n");
+	
     for (i = 2; i < ntokens; ++i)
     {
 	s = symbol_name[i];
 	if (is_C_identifier(s))
 	{
-	    fprintf(dc_file, "#define ");
+	    fprintf(dc_file, "    ");
 	    c = *s;
 	    if (c == '"')
 	    {
@@ -878,9 +891,12 @@ void output_defines()
 		while ((c = *++s));
 	    }
 	    if (!dflag) ++outline;
-	    fprintf(dc_file, " %d\n", symbol_value[i]);
+	    fprintf(dc_file, " = %d,\n", symbol_value[i]);
 	}
     }
+	fprintf(dc_file, "};\n\n");
+	}
+	}
 
     ++outline;
     fprintf(dc_file, "#define YYERRCODE %d\n", symbol_value[1]);
@@ -974,8 +990,6 @@ void output_debug()
 
     if (!rflag) ++outline;
     fprintf(output_file, "#if YYDEBUG\n");
-    if (!rflag)
-	fprintf(output_file, "static ");
     fprintf(output_file, "char *%sname[] = {", symbol_prefix);
     j = 80;
     for (i = 0; i <= max; ++i)

--- a/readskel.c
+++ b/readskel.c
@@ -10,7 +10,7 @@ static char	**ap, **ap_end, **ap_start;
 static void add_ptr(char *p)
 {
     if (ap == ap_end) {
-	int size = CHUNK;
+	size_t size = CHUNK;
 	char **nap;
 	while ((ap-ap_start) * sizeof(char *) >= size)
 	    size = size * 2;


### PR DESCRIPTION
Hi

This PR brings enum to btyacc:
-- btyacc is using enum instead of predefined constants in defs.h
-- btyacc generates enum [class] YYTOKEN instead of predefined constants for the tokens.

Also, yyname is no more static to allow access of the symbol's name from outside the compile unit.
