### PR TITLE
Avoid crash when an input pops up an Action error at the first token

### DIFF
--- a/BtYacc-w32-vs120.vcxproj
+++ b/BtYacc-w32-vs120.vcxproj
@@ -80,17 +80,9 @@
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>
-    <None Include="..\btyaccpa.ske" />
     <None Include="..\build.h.in" />
-    <None Include="..\CHANGELOG" />
     <None Include="..\empty.y" />
-    <None Include="..\Makefile" />
-    <None Include="..\makefile.dos" />
     <None Include="..\manpage" />
-    <None Include="..\push.skel" />
-    <None Include="..\README" />
-    <None Include="..\README.BYACC" />
-    <None Include="..\skel2c" />
     <None Include="..\test\ansiC.y" />
     <None Include="..\test\ansiC2.y" />
     <None Include="..\test\error.y" />

--- a/BtYacc-w32-vs120.vcxproj.filters
+++ b/BtYacc-w32-vs120.vcxproj.filters
@@ -18,8 +18,6 @@
     </Filter>
   </ItemGroup>
   <ItemGroup>
-    <None Include="..\btyaccpa.ske" />
-    <None Include="..\push.skel" />
     <None Include="..\empty.y" />
     <None Include="..\test\ansiC.y">
       <Filter>test</Filter>
@@ -42,17 +40,11 @@
     <None Include="..\test\test.y">
       <Filter>test</Filter>
     </None>
-    <None Include="..\Makefile" />
     <None Include="..\manpage" />
-    <None Include="..\README" />
-    <None Include="..\skel2c" />
-    <None Include="..\README.BYACC" />
-    <None Include="..\makefile.dos" />
     <None Include="..\build.h.in" />
     <None Include="..\test\t3.y">
       <Filter>test</Filter>
     </None>
-    <None Include="..\CHANGELOG" />
     <None Include="CHANGELOG" />
     <None Include="Makefile" />
     <None Include="manpage" />

--- a/btyaccpa.ske
+++ b/btyaccpa.ske
@@ -371,6 +371,8 @@ int yyparse() {
   }
 #endif
   
+  yym = 0;
+  yyn = 0;
   yyps = YYNewState(YYDEFSTACKSIZE);
   yyps->save = 0;
   yynerrs = 0;

--- a/skeleton.c
+++ b/skeleton.c
@@ -393,6 +393,8 @@ static char *body[] =
     "  }",
     "#endif",
     "  ",
+    "  yym = 0;",
+    "  yyn = 0;",
     "  yyps = YYNewState(YYDEFSTACKSIZE);",
     "  yyps->save = 0;",
     "  yynerrs = 0;",


### PR DESCRIPTION
Hi

This PR fixes the initialisation of yym & yyn to 0 to avoid a crash  when an input pops up an Action error at the first token.