### PR TITLE
Add CMake build tooling

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,90 @@
+cmake_minimum_required(VERSION 3.1)
+
+project(btyacc C)
+
+# ---- btyacc executable ----
+
+set(src "${PROJECT_SOURCE_DIR}")
+set(bin "${PROJECT_BINARY_DIR}")
+add_custom_command(
+    OUTPUT skeleton.c
+    COMMAND "${CMAKE_COMMAND}"
+    "-Dinput=${src}/btyaccpa.ske"
+    "-Doutput=${bin}/skeleton.c.tmp"
+    "-P${src}/cmake/skel2c.cmake"
+    COMMAND "${CMAKE_COMMAND}" -E copy_if_different
+    "${bin}/skeleton.c.tmp"
+    "${bin}/skeleton.c"
+    COMMAND "${CMAKE_COMMAND}" -E remove "${bin}/skeleton.c.tmp"
+    MAIN_DEPENDENCY btyaccpa.ske
+    DEPENDS cmake/skel2c.cmake
+    COMMENT "skel2c [btyaccpa.ske -> skeleton.c]"
+    VERBATIM
+)
+
+add_executable(
+    btyacc
+    closure.c
+    dtor.c
+    error.c
+    lalr.c
+    lr0.c
+    main.c
+    mkpar.c
+    output.c
+    mstring.c
+    reader.c
+    readskel.c
+    skeleton.c
+    symtab.c
+    verbose.c
+    warshall.c
+    "${bin}/skeleton.c"
+)
+
+target_include_directories(btyacc PRIVATE "${src}")
+
+# ---- Install rules ----
+
+if(CMAKE_SKIP_INSTALL_RULES)
+  return()
+endif()
+
+include(GNUInstallDirs)
+
+install(
+    TARGETS btyacc
+    EXPORT btyaccTargets
+    RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}" COMPONENT btyacc_Runtime
+)
+
+set(CMAKE_INSTALL_DEFAULT_COMPONENT_NAME btyacc_Development)
+
+set(
+    btyacc_INSTALL_CMAKEDIR "${CMAKE_INSTALL_DATADIR}/btyacc"
+    CACHE PATH "CMake package config location relative to the install prefix"
+)
+mark_as_advanced(btyacc_INSTALL_CMAKEDIR)
+
+install(
+    EXPORT btyaccTargets
+    NAMESPACE btyacc::
+    DESTINATION "${btyacc_INSTALL_CMAKEDIR}"
+)
+
+if(CMAKE_VERSION VERSION_LESS "3.14")
+  set(maybe_exe btyacc)
+  if(WIN32)
+    set(maybe_exe btyacc.exe)
+  endif()
+  set(btyacc_EXECUTABLE_NAME "${maybe_exe}" CACHE STRING "Executable name")
+else()
+  cmake_policy(SET CMP0087 NEW)
+  set(btyacc_EXECUTABLE_NAME "$<TARGET_FILE_NAME:btyacc>")
+endif()
+install(CODE "set(btyacc_NAME [[${btyacc_EXECUTABLE_NAME}]])")
+
+install(CODE "set(btyacc_INSTALL_CMAKEDIR [[${btyacc_INSTALL_CMAKEDIR}]])")
+install(CODE "set(CMAKE_INSTALL_BINDIR [[${CMAKE_INSTALL_BINDIR}]])")
+
+install(SCRIPT cmake/install.cmake)

--- a/cmake/install.cmake
+++ b/cmake/install.cmake
@@ -1,0 +1,12 @@
+get_filename_component(prefix "${CMAKE_INSTALL_PREFIX}" ABSOLUTE)
+
+file(
+    RELATIVE_PATH relative_path
+    "/${btyacc_INSTALL_CMAKEDIR}" "/${CMAKE_INSTALL_BINDIR}/${btyacc_NAME}"
+)
+
+file(WRITE "${prefix}/${btyacc_INSTALL_CMAKEDIR}/btyaccConfig.cmake" "\
+set(BTYACC_EXECUTABLE \"\${CMAKE_CURRENT_LIST_DIR}/${relative_path}\")
+
+include(\"\${CMAKE_CURRENT_LIST_DIR}/btyaccTargets.cmake\")
+")

--- a/cmake/skel2c.cmake
+++ b/cmake/skel2c.cmake
@@ -1,0 +1,71 @@
+cmake_minimum_required(VERSION 3.1)
+
+function(append string)
+  file(APPEND "${output}" "${string}")
+endfunction()
+
+file(READ "${input}" content)
+
+# BEGIN
+set(havesection NO)
+set(section "")
+set(seclist "")
+set(FNR 1)
+get_filename_component(FILENAME "${input}" NAME)
+
+file(WRITE "${output}" "\
+/*
+** This file generated automatically from ${FILENAME}
+*/
+
+#include \"defs.h\"
+")
+
+# body
+
+string(REGEX REPLACE "\n$" "" content "${content}")
+string(REPLACE "\\\n" "\\ \n" content "${content}")
+string(REPLACE ";" "\;" content "${content}")
+string(REPLACE "\n" ";" content "${content}")
+
+foreach(line IN LISTS content)
+  math(EXPR FNR "${FNR} + 1")
+  string(REGEX REPLACE "\\\\ $" "\\\\" line "${line}")
+  if(line MATCHES "^%%")
+    if(havesection)
+      append("    0\n};\n\n")
+    endif()
+    if(line MATCHES "^%% [^ ]+")
+      string(SUBSTRING "${line}" 3 -1 section)
+      set(havesection YES)
+      list(APPEND seclist "${section}")
+      append("static char *${section}[] =\n{\n")
+      append("    \"#line ${FNR} \\\"${FILENAME}\\\"\",\n")
+    else()
+      set(havesection NO)
+    endif()
+    continue()
+  endif()
+  if(havesection)
+    string(REPLACE "\\" "\\\\" line "${line}")
+    string(REPLACE "\t" "\\t" line "${line}")
+    string(REPLACE "\"" "\\\"" line "${line}")
+    append("    \"${line}\",\n")
+  else()
+    append("${line}\n")
+  endif()
+endforeach()
+
+# END
+
+if(havesection)
+  append("    0\n};\n\n")
+endif()
+
+if(NOT seclist STREQUAL "")
+  append("struct section section_list[] = {\n")
+  foreach(sec IN LISTS seclist)
+    append("\t{ \"${sec}\", &${sec}[0] },\n")
+  endforeach()
+  append("\t{ 0, 0 } };\n")
+endif()

--- a/main.c
+++ b/main.c
@@ -1,7 +1,11 @@
 #include "defs.h"
 #include <signal.h>
 #include <stdio.h>
+#ifdef _WIN32
+#include <io.h>
+#else
 #include <unistd.h>
+#endif
 
 char dflag;
 char lflag;


### PR DESCRIPTION
This PR adds CMake build scripts.

The AWK script is replaced with a CMake script as well. It produces the exact same output as the AWK script. There is one edge case for this however. Due to how CMake handles lists, I have to transform end-of-line backslashes to `\ `, so they do not unintentionally escape separators.

`unistd.h` does not exist on Windows. On Windows, `io.h` is included instead.

The install rules are as complicated as they are only because I wanted to also support clients using CMake, so they can just use btyacc like so:

```cmake
find_package(btyacc REQUIRED)
execute_process(COMMAND "${BTYACC_EXECUTABLE}" ...)
```

Everything after line 60 in `CMakeLists.txt` and the `cmake/install.cmake` script are there to implement that.