### PR TITLE
Fix minimum required CMake version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.2)
 
 project(btyacc C)
 
@@ -11,7 +11,7 @@ add_custom_command(
     COMMAND "${CMAKE_COMMAND}"
     "-Dinput=${src}/btyaccpa.ske"
     "-Doutput=${bin}/skeleton.c.tmp"
-    "-P${src}/cmake/skel2c.cmake"
+    -P "${src}/cmake/skel2c.cmake"
     COMMAND "${CMAKE_COMMAND}" -E copy_if_different
     "${bin}/skeleton.c.tmp"
     "${bin}/skeleton.c"

--- a/cmake/skel2c.cmake
+++ b/cmake/skel2c.cmake
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.2)
 
 function(append string)
   file(APPEND "${output}" "${string}")


### PR DESCRIPTION
Apologies for the hasty hotfix PR for #27, but I should have tested the build with the CMake version I declared as a minimum. The Conan CI run revealed that my minimum version was not actually correct, because in the `skel2c.cmake` script I used the `continue()` command, which was actually introduced in CMake 3.2.

I have also passed the script in a wrong format, because only `-P` requires its argument to be separate. Quirks of old CMake versions that have fortunately been fixed in more recent versions.